### PR TITLE
feat: apply line highlight only on focused buffer

### DIFF
--- a/lua/modes/config.lua
+++ b/lua/modes/config.lua
@@ -8,6 +8,7 @@ M.default = {
 		visual = '#9745be',
 	},
 	line_opacity = 0.15,
+	focus_only = false,
 }
 
 return M

--- a/lua/modes/init.lua
+++ b/lua/modes/init.lua
@@ -193,7 +193,7 @@ function modes.setup(opts)
 			'lua require("modes").set_highlights("insert")',
 		},
 		{
-			'CmdlineLeave,InsertLeave,TextYankPost',
+			'CmdlineLeave,InsertLeave,TextYankPost,WinLeave',
 			'*',
 			'lua require("modes").reset()',
 		},

--- a/lua/modes/init.lua
+++ b/lua/modes/init.lua
@@ -185,21 +185,26 @@ function modes.setup(opts)
 		end
 	end)
 
-	util.define_augroups({
-		_modes = {
-			{ 'ColorScheme', '*', 'lua require("modes").set_colors()' },
-			{
-				'InsertEnter',
-				'*',
-				'lua require("modes").set_highlights("insert")',
-			},
-			{
-				'CmdlineLeave,InsertLeave,TextYankPost',
-				'*',
-				'lua require("modes").reset()',
-			},
+	local autocmds = {
+		{ 'ColorScheme', '*', 'lua require("modes").set_colors()' },
+		{
+			'InsertEnter',
+			'*',
+			'lua require("modes").set_highlights("insert")',
 		},
-	})
+		{
+			'CmdlineLeave,InsertLeave,TextYankPost',
+			'*',
+			'lua require("modes").reset()',
+		},
+	}
+
+	if config.focus_only then
+		autocmds['cl'] = { 'WinEnter', '*', 'set cursorline' }
+		autocmds['nocl'] = { 'WinLeave', '*', 'set nocursorline' }
+	end
+
+	util.define_augroups({ _modes = autocmds })
 end
 
 return modes


### PR DESCRIPTION
This option enabled by passing `focus_only = true` to the options, the default is set to false, or do you think it is better to enabled by default ?