### PR TITLE
feat: allows user to set line highlight opacity per mode

### DIFF
--- a/lua/modes/config.lua
+++ b/lua/modes/config.lua
@@ -7,7 +7,12 @@ M.default = {
 		insert = '#78ccc5',
 		visual = '#9745be',
 	},
-	line_opacity = 0.15,
+	line_opacity = {
+		copy = 0.15,
+		delete = 0.15,
+		insert = 0.15,
+		visual = 0.15,
+	},
 	focus_only = false,
 }
 

--- a/lua/modes/init.lua
+++ b/lua/modes/init.lua
@@ -124,7 +124,20 @@ function modes.setup(opts)
 
 	-- Set opts with fallback to default.
 	setmetatable(opts or {}, { __index = default })
-	setmetatable(opts.line_opacity or {}, { __index = default.line_opacity })
+	if type(opts.line_opacity) == 'number' then
+		opts.line_opacity = {
+			copy = opts.line_opacity,
+			delete = opts.line_opacity,
+			insert = opts.line_opacity,
+			visual = opts.line_opacity,
+		}
+	else
+		setmetatable(
+			opts.line_opacity or {},
+			{ __index = default.line_opacity }
+		)
+	end
+
 	config = opts
 
 	-- Hack to ensure theme colors get loaded properly

--- a/lua/modes/init.lua
+++ b/lua/modes/init.lua
@@ -74,21 +74,25 @@ function modes.set_colors()
 		),
 	}
 	dim_colors = {
-		copy = util.blend(colors.copy, init_colors.normal, config.line_opacity),
+		copy = util.blend(
+			colors.copy,
+			init_colors.normal,
+			config.line_opacity.copy
+		),
 		delete = util.blend(
 			colors.delete,
 			init_colors.normal,
-			config.line_opacity
+			config.line_opacity.delete
 		),
 		insert = util.blend(
 			colors.insert,
 			init_colors.normal,
-			config.line_opacity
+			config.line_opacity.insert
 		),
 		visual = util.blend(
 			colors.visual,
 			init_colors.normal,
-			config.line_opacity
+			config.line_opacity.visual
 		),
 	}
 
@@ -104,9 +108,15 @@ end
 ---@field insert string
 ---@field visual string
 
+---@class Opacity
+---@field copy number between 0 and 1
+---@field delete number between 0 and 1
+---@field insert number between 0 and 1
+---@field visual number between 0 and 1
+
 ---@class Config
 ---@field colors Colors
----@field line_opacity number between 0 and 1
+---@field line_opacity Opacity
 
 ---@param opts Config
 function modes.setup(opts)
@@ -114,6 +124,7 @@ function modes.setup(opts)
 
 	-- Set opts with fallback to default.
 	setmetatable(opts or {}, { __index = default })
+	setmetatable(opts.line_opacity or {}, { __index = default.line_opacity })
 	config = opts
 
 	-- Hack to ensure theme colors get loaded properly


### PR DESCRIPTION
This is just my preferences, i like to have different opacity for each mode, such as fully transparent in insert mode (because I find it distracting to have cursor line highlighted when typing but still want line number to have color) and nearly opaque for delete mode.

This feature allows the user to set the opacity for each mode.

```lua
line_opacity = {
        delete = 0.75,
        insert = 0,
}
```

The options above will make the line highlight in insert mode fully transparent, in delete mode will be nearly opaque, and the rest will use the default values.

Feel free to close this if it does not suit with the purpose of this plugin.