### PR TITLE
fix: allows user to override `line_opacity` with partial option

### DIFF
--- a/lua/modes/init.lua
+++ b/lua/modes/init.lua
@@ -120,7 +120,12 @@ function modes.setup(opts)
 	local default_config = {
 		-- Colors intentionally set to {} to prioritise theme values
 		colors = {},
-		line_opacity = 0.15,
+		line_opacity = {
+			copy = 0.15,
+			delete = 0.15,
+			insert = 0.15,
+			visual = 0.15,
+		},
 		focus_only = false,
 	}
 	opts = opts or default_config


### PR DESCRIPTION
From 62ab633b0bb229b5c4faedaf4f784a72e68cc624, the default value of `line_opacity` is a number, when user want to override the `line_opacity` per mode, they have to pass the complete value.

Using table, user can pass config like this
```lua
require("modes").setup({
  -- ...
  -- instead of: line_opacity = { copy = 0.15, delete = 0.15, insert = 0, visual = 0.2 },
  -- user can pass the mode they want to override
  line_opacity = { insert = 0, visual = 0.2 },
  -- ...
})
```