### PR TITLE
fix: add back normal group fallback

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -73,11 +73,11 @@ end
 
 M.define = function()
 	default_colors = {
-		cursor_line = utils.get_bg('CursorLine'),
-		cursor_line_nr = utils.get_bg('CursorLineNr'),
-		mode_msg = utils.get_fg('ModeMsg'),
+		cursor_line = utils.get_bg('CursorLine', 'CursorLine'),
+		cursor_line_nr = utils.get_bg('CursorLineNr', 'CursorLineNr'),
+		mode_msg = utils.get_fg('ModeMsg', 'ModeMsg'),
 		normal = utils.get_bg('Normal', 'Normal'),
-		visual = utils.get_bg('Visual'),
+		visual = utils.get_bg('Visual', 'Visual'),
 	}
 	colors = {
 		copy = config.colors.copy or utils.get_bg('ModesCopy', '#f5c359'),

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -76,7 +76,7 @@ M.define = function()
 		cursor_line = utils.get_bg('CursorLine'),
 		cursor_line_nr = utils.get_bg('CursorLineNr'),
 		mode_msg = utils.get_fg('ModeMsg'),
-		normal = utils.get_bg('Normal'),
+		normal = utils.get_bg('Normal', 'Normal'),
 		visual = utils.get_bg('Visual'),
 	}
 	colors = {


### PR DESCRIPTION
Fixes #23.

Adding back the fallback for the normal group resolves the normal bg group lacking a value and allows modes to work as expected. See #23 for further details.