### PR TITLE
refactor: use window-local highlights

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -80,16 +80,9 @@ M.define = function()
 	vim.cmd('hi ModesVisual guibg=' .. colors.visual)
 
 	for _, mode in ipairs({ 'Copy', 'Delete', 'Insert', 'Visual' }) do
-		local cursorline = ('Modes%sCursorLine'):format(mode)
-		local cursorline_nr = ('Modes%sCursorLineNr'):format(mode)
-		utils.set_hl_if_not_exist(
-			cursorline,
-			{ bg = blended_colors[mode:lower()] }
-		)
-		utils.set_hl_if_not_exist(
-			cursorline_nr,
-			{ bg = blended_colors[mode:lower()] }
-		)
+		local def = { bg = blended_colors[mode:lower()] }
+		utils.set_hl_if_not_exist(('Modes%sCursorLine'):format(mode), def)
+		utils.set_hl_if_not_exist(('Modes%sCursorLineNr'):format(mode), def)
 	end
 
 	utils.set_hl('ModeMsgInsert', { fg = colors.insert })

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -177,6 +177,8 @@ M.setup = function(opts)
 		}
 	end
 
+	M.define()
+
 	vim.on_key(function(key)
 		local ok, current_mode = pcall(vim.fn.mode)
 		if not ok then

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -48,16 +48,14 @@ end
 ---Update highlights
 ---@param scene 'default'|'insert'|'visual'|'copy'|'delete'|
 M.highlight = function(scene)
-	if scene == 'delete' then
-		utils.set_hl('ModesOperator', { link = 'ModesDelete' })
-	end
-
-	if scene == 'copy' then
-		utils.set_hl('ModesOperator', { link = 'ModesCopy' })
-	end
-
 	local value = table.concat(winhighlight[scene] or {}, ',')
 	vim.api.nvim_win_set_option(0, 'winhighlight', value)
+
+	if scene == 'delete' then
+		utils.set_hl('ModesOperator', { link = 'ModesDelete' })
+	elseif scene == 'copy' then
+		utils.set_hl('ModesOperator', { link = 'ModesCopy' })
+	end
 end
 
 M.define = function()

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -173,10 +173,15 @@ M.setup = function(opts)
 			end
 
 			if
-				(key:lower() == 'v' or key == utils.replace_termcodes('<c-v>'))
-				and not operator_started
+				key:lower() == 'v'
+				or key == utils.replace_termcodes('<c-v>')
 			then
-				M.highlight('visual')
+				if operator_started then
+					M.reset()
+				else
+					M.highlight('visual')
+					operator_started = true
+				end
 			end
 		end
 
@@ -184,7 +189,10 @@ M.setup = function(opts)
 			current_mode:lower() == 'v'
 			or current_mode == utils.replace_termcodes('<c-v>')
 		then
-			if key == utils.replace_termcodes('<esc>') then
+			if
+				key == utils.replace_termcodes('<esc>')
+				or key == current_mode
+			then
 				M.reset()
 			end
 		end

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -29,7 +29,7 @@ local winhighlight = {
 	insert = {
 		CursorLine = 'ModesInsertCursorLine',
 		CursorLineNr = 'ModesInsertCursorLineNr',
-		ModeMsg = 'ModeMsgInsert',
+		ModeMsg = 'ModesInsertModeMsg',
 	},
 	delete = {
 		CursorLine = 'ModesDeleteCursorLine',
@@ -38,8 +38,8 @@ local winhighlight = {
 	visual = {
 		CursorLine = 'ModesVisualCursorLine',
 		CursorLineNr = 'ModesVisualCursorLineNr',
-		ModeMsg = 'ModeMsgVisual',
-		Visual = 'VisualVisual',
+		ModeMsg = 'ModesVisualModeMsg',
+		Visual = 'ModesVisualVisual',
 	},
 }
 local colors = {}
@@ -55,11 +55,11 @@ end
 ---@param scene 'default'|'insert'|'visual'|'copy'|'delete'|
 M.highlight = function(scene)
 	local winhl_map = {}
-	local old_value = vim.api.nvim_win_get_option(0, 'winhighlight')
+	local prev_value = vim.api.nvim_win_get_option(0, 'winhighlight')
 
 	-- mapping the old value of 'winhighlight'
-	if old_value ~= '' then
-		for _, winhl in ipairs(vim.split(old_value, ',')) do
+	if prev_value ~= '' then
+		for _, winhl in ipairs(vim.split(prev_value, ',')) do
 			local pair = vim.split(winhl, ':')
 			winhl_map[pair[1]] = pair[2]
 		end
@@ -86,7 +86,7 @@ M.highlight = function(scene)
 end
 
 M.define = function()
-	local base = utils.get_bg('Normal', 'Normal')
+	local normal_bg = utils.get_bg('Normal', 'Normal')
 	colors = {
 		copy = config.colors.copy or utils.get_bg('ModesCopy', '#f5c359'),
 		delete = config.colors.delete or utils.get_bg('ModesDelete', '#c75c6a'),
@@ -94,10 +94,22 @@ M.define = function()
 		visual = config.colors.visual or utils.get_bg('ModesVisual', '#9745be'),
 	}
 	blended_colors = {
-		copy = utils.blend(colors.copy, base, config.line_opacity.copy),
-		delete = utils.blend(colors.delete, base, config.line_opacity.delete),
-		insert = utils.blend(colors.insert, base, config.line_opacity.insert),
-		visual = utils.blend(colors.visual, base, config.line_opacity.visual),
+		copy = utils.blend(colors.copy, normal_bg, config.line_opacity.copy),
+		delete = utils.blend(
+			colors.delete,
+			normal_bg,
+			config.line_opacity.delete
+		),
+		insert = utils.blend(
+			colors.insert,
+			normal_bg,
+			config.line_opacity.insert
+		),
+		visual = utils.blend(
+			colors.visual,
+			normal_bg,
+			config.line_opacity.visual
+		),
 	}
 
 	---Create highlight groups
@@ -112,9 +124,9 @@ M.define = function()
 		utils.set_hl(('Modes%sCursorLineNr'):format(mode), def, true)
 	end
 
-	utils.set_hl('ModeMsgInsert', { fg = colors.insert })
-	utils.set_hl('ModeMsgVisual', { fg = colors.visual })
-	utils.set_hl('VisualVisual', { bg = blended_colors.visual })
+	utils.set_hl('ModesInsertModeMsg', { fg = colors.insert })
+	utils.set_hl('ModesVisualModeMsg', { fg = colors.visual })
+	utils.set_hl('ModesVisualVisual', { bg = blended_colors.visual })
 end
 
 M.enable_managed_ui = function()

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -83,8 +83,8 @@ M.define = function()
 
 	for _, mode in ipairs({ 'Copy', 'Delete', 'Insert', 'Visual' }) do
 		local def = { bg = blended_colors[mode:lower()] }
-		utils.set_hl_if_not_exist(('Modes%sCursorLine'):format(mode), def)
-		utils.set_hl_if_not_exist(('Modes%sCursorLineNr'):format(mode), def)
+		utils.set_hl(('Modes%sCursorLine'):format(mode), def, true)
+		utils.set_hl(('Modes%sCursorLineNr'):format(mode), def, true)
 	end
 
 	utils.set_hl('ModeMsgInsert', { fg = colors.insert })

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -51,10 +51,12 @@ M.highlight = function(scene)
 	local value = table.concat(winhighlight[scene] or {}, ',')
 	vim.api.nvim_win_set_option(0, 'winhighlight', value)
 
-	if scene == 'delete' then
-		utils.set_hl('ModesOperator', { link = 'ModesDelete' })
-	elseif scene == 'copy' then
-		utils.set_hl('ModesOperator', { link = 'ModesCopy' })
+	if config.set_cursor then
+		if scene == 'delete' then
+			utils.set_hl('ModesOperator', { link = 'ModesDelete' })
+		elseif scene == 'copy' then
+			utils.set_hl('ModesOperator', { link = 'ModesCopy' })
+		end
 	end
 end
 

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -19,7 +19,6 @@ local winhighlight = {
 	default = {
 		CursorLine = 'CursorLine',
 		CursorLineNr = 'CursorLineNr',
-		ModeMsg = 'ModeMsg',
 		Visual = 'Visual',
 	},
 	copy = {
@@ -29,7 +28,6 @@ local winhighlight = {
 	insert = {
 		CursorLine = 'ModesInsertCursorLine',
 		CursorLineNr = 'ModesInsertCursorLineNr',
-		ModeMsg = 'ModesInsertModeMsg',
 	},
 	delete = {
 		CursorLine = 'ModesDeleteCursorLine',
@@ -38,7 +36,6 @@ local winhighlight = {
 	visual = {
 		CursorLine = 'ModesVisualCursorLine',
 		CursorLineNr = 'ModesVisualCursorLineNr',
-		ModeMsg = 'ModesVisualModeMsg',
 		Visual = 'ModesVisualVisual',
 	},
 }
@@ -75,6 +72,14 @@ M.highlight = function(scene)
 		table.insert(new_value, ('%s:%s'):format(builtin, hl))
 	end
 	vim.api.nvim_win_set_option(0, 'winhighlight', table.concat(new_value, ','))
+
+	if vim.api.nvim_get_option('showmode') then
+		if scene == 'visual' then
+			utils.set_hl('ModeMsg', { link = 'ModesVisualModeMsg' })
+		elseif scene == 'insert' then
+			utils.set_hl('ModeMsg', { link = 'ModesInsertModeMsg' })
+		end
+	end
 
 	if config.set_cursor then
 		if scene == 'delete' then

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -168,6 +168,10 @@ M.setup = function(opts)
 				end
 			end
 
+			if key == utils.replace_termcodes('<c-w>') then
+				operator_started = true
+			end
+
 			if
 				(key:lower() == 'v' or key == utils.replace_termcodes('<c-v>'))
 				and not operator_started

--- a/lua/modes/utils.lua
+++ b/lua/modes/utils.lua
@@ -60,6 +60,14 @@ M.set_hl = function(name, color)
 	vim.cmd('hi ' .. name .. ' guibg=' .. bg .. ' guifg=' .. fg)
 end
 
+M.set_hl_if_not_exist = function (name, color)
+	if pcall(vim.api.nvim_get_hl_by_name, name, true) then
+		return
+	end
+
+	M.set_hl(name, color)
+end
+
 M.get_fg = function(name, fallback)
 	local id = vim.api.nvim_get_hl_id_by_name(name)
 	if not id then

--- a/lua/modes/utils.lua
+++ b/lua/modes/utils.lua
@@ -47,8 +47,8 @@ end
 ---Set highlight
 ---@param name string
 ---@param color Color
----@param if_not_exist? boolean
-M.set_hl = function(name, color, if_not_exist)
+---@param if_not_exists? boolean
+M.set_hl = function(name, color, if_not_exists)
 	if color.link ~= nil then
 		vim.cmd('hi ' .. name .. ' guibg=none guifg=none')
 		vim.cmd('hi! link ' .. name .. ' ' .. color.link)
@@ -58,7 +58,7 @@ M.set_hl = function(name, color, if_not_exist)
 	local bg = color.bg or 'none'
 	local fg = color.fg or 'none'
 
-	if if_not_exist then
+	if if_not_exists then
 		if pcall(vim.api.nvim_get_hl_by_name, name, true) then
 			return
 		end

--- a/lua/modes/utils.lua
+++ b/lua/modes/utils.lua
@@ -47,7 +47,8 @@ end
 ---Set highlight
 ---@param name string
 ---@param color Color
-M.set_hl = function(name, color)
+---@param if_not_exist? boolean
+M.set_hl = function(name, color, if_not_exist)
 	if color.link ~= nil then
 		vim.cmd('hi ' .. name .. ' guibg=none guifg=none')
 		vim.cmd('hi! link ' .. name .. ' ' .. color.link)
@@ -57,15 +58,13 @@ M.set_hl = function(name, color)
 	local bg = color.bg or 'none'
 	local fg = color.fg or 'none'
 
-	vim.cmd('hi ' .. name .. ' guibg=' .. bg .. ' guifg=' .. fg)
-end
-
-M.set_hl_if_not_exist = function (name, color)
-	if pcall(vim.api.nvim_get_hl_by_name, name, true) then
-		return
+	if if_not_exist then
+		if pcall(vim.api.nvim_get_hl_by_name, name, true) then
+			return
+		end
 	end
 
-	M.set_hl(name, color)
+	vim.cmd('hi ' .. name .. ' guibg=' .. bg .. ' guifg=' .. fg)
 end
 
 M.get_fg = function(name, fallback)


### PR DESCRIPTION
Putting a rough implementation here to get some feedback if anyone is interested

The current implementation of how we handle the cursor line color for each mode is to override the `CursorLine` highlight group, which leads to the following issues/limitations (at least for me):

1. Assuming that `CursorLine` and `CursorLineNr` have `bg`
  Related issue: #16
  https://github.com/mvllow/modes.nvim/blob/1086d94b1f7d6ba105593a1dd21e2cb02ab92fc0/lua/modes.lua#L76-L77
  Depending on the color scheme, we may override the default color in NORMAL mode if the highligh group does not have `bg` (although we have `config.set_*` as a *workaround*)

  
    > My LineNr is blue, once modes.nvim is activated, it turns white

    https://user-images.githubusercontent.com/55179750/172336733-d67c0a96-0530-42eb-a0a8-afa9835810b5.mp4



2. We can not override the highlight groups on the fly for testing purposes
  Related issue: #18
  https://github.com/mvllow/modes.nvim/blob/1086d94b1f7d6ba105593a1dd21e2cb02ab92fc0/lua/modes.lua#L40-L46
  Since for every *mode-switching*, we redefine the highlight group using the initial config color

3. We have a strong opinions about `CursorLineNr`
  https://github.com/mvllow/modes.nvim/blob/1086d94b1f7d6ba105593a1dd21e2cb02ab92fc0/lua/modes.lua#L41-L43
  We assume that `CursorLineNr` the have the same definition as `CursorLine`

4. If we open nvim with an initial window that set `CursorLine`, we end up using that definition for NORMAL mode
  For example, if we open nvim with `-c ':Telescope find_file'`, NORMAL mode will use INSERT mode style since in `setup()` we are trying to extract color definition from `CursorLine`, as the result, we are using whatever the initial window defined for `CursorLine`
    

    https://user-images.githubusercontent.com/55179750/172337470-315d8834-77ea-46a9-b806-40f991ab50b2.mp4

---

This implementation is to address of these problems

By using `winhighlight` option, we have the flexibility to set `CursorLine`/`CursorLineNr` without overriding it, it is a local-window option, also we can have different definition between `CursorLine`/`CursorLineNr` so color scheme developer has more control to style those components.

We don't need to redefine highlight groups for every *mode-switcing* as it is already been done in `define()` except for `ModesOperator` (*only built-in `highlight-groups` are supported by `winhighlight`*).

In the meantime, I've removed this lines as I can't find it's usage, but I'm free to add it back

https://github.com/mvllow/modes.nvim/blob/1086d94b1f7d6ba105593a1dd21e2cb02ab92fc0/lua/modes.lua#L161-L164


This implementation provides the following highlight groups
> subject to change, I'm not good at naming

- `Modes*CursorLine`, map for `CursorLine`
- `Modes*CursorLineNr`, map for `CursorLineNr`
- `ModeMsg*`, map for `ModeMsg`
- `VisualVisual`, map for `Visual` (*sorry for the name*)

Now user can define any style they want

- The default, `CursorLineNr` - `CursorLine` have same definition

- The old style, `CursorLineNr` fg - `CursorLine` bg

    https://user-images.githubusercontent.com/55179750/172339592-7f9502b8-4dfe-4c14-a8fc-58f3dcf09225.mp4

- `CursorLineNr` fg with blended bg

    https://user-images.githubusercontent.com/55179750/172340466-5685579a-799a-4ad9-9375-2904ac9075c6.mp4

- `CursorLinrNr` fg with different blended intensity bg

    https://user-images.githubusercontent.com/55179750/172342587-dee3aac9-8094-4bdc-839f-0840d10181b3.mp4

  or `LineNr` with different bg

    https://user-images.githubusercontent.com/55179750/172342137-f6c11e4e-d165-4d2e-bd77-64ed93b70674.mp4



In addition of these changes, this implementation also changes this behavior:

Opens a split window with the same buffer and view port, the VISUAL style is only applied to the focused window

> Old behavior
![20220607_171815_full](https://user-images.githubusercontent.com/55179750/172344581-57f1b64a-b173-4ac8-9d53-4b0e398e6267.jpg)

> New behavior
![20220607_171711_full](https://user-images.githubusercontent.com/55179750/172344793-932bdfe8-da7d-481a-bc66-bf2fd5b0f441.jpg)

---

If this change is accepted, there are a few things I'd like to change in this PR (or in the future PRs):

- Use `CursorLineNr` (*fallback to `LineNr`, `Normal`*)  background to use for `Modes*CursorLineNr` blended color
  If the color scheme has a different background to it, user still get nice blended color if they use the default styles
- Refactor fallback mechanism to accept list of highlight groups, and then a hex color
  I have something like this in my config: https://github.com/fitrh/init.nvim/blob/main/lua/sugar/highlight.lua#L34-L65
- > *Maybe I need to squash*

I've been using this for a week and it seems to work, but it would be helpful if anyone could help test it.