### PR TITLE
fix: operator highlighting with cutlass mappings

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -195,64 +195,48 @@ M.setup = function(opts)
 		local ok, current_mode = pcall(vim.fn.mode)
 		if not ok then
 			M.reset()
-		end
+		 else
+			if current_mode == 'i' then
+				if key == utils.replace_termcodes('<esc>') then
+					M.reset()
+					return
+				end
+		    end
 
-		if current_mode == 'i' then
-			if key == utils.replace_termcodes('<esc>') then
-				M.reset()
-			end
-		end
-
-		if current_mode == 'n' then
-			if key == utils.replace_termcodes('<esc>') then
-				M.reset()
-			end
-
-			if key == 'y' then
+			if current_mode == 'n' then
+				-- reset if coming back from operator pending mode
 				if operator_started then
 					M.reset()
-				else
+					return
+				 end
+
+				if key == 'y' then
 					M.highlight('copy')
 					operator_started = true
+					return
 				end
-			end
 
-			if key == 'd' then
-				if operator_started then
-					M.reset()
-				else
+				if key == 'd' then
 					M.highlight('delete')
 					operator_started = true
+					return
 				end
-			end
+		   end
 
-			if key == utils.replace_termcodes('<c-w>') then
-				operator_started = true
-			end
-
-			if
-				key:lower() == 'v'
-				or key == utils.replace_termcodes('<c-v>')
-			then
-				if operator_started then
+		   if
+				current_mode:lower() == 'v'
+				or current_mode == utils.replace_termcodes('<c-v>')
+		   then
+			   if
+					key == utils.replace_termcodes('<esc>')
+					or key == current_mode
+			   then
 					M.reset()
-				else
+			   else
 					M.highlight('visual')
 					operator_started = true
-				end
-			end
-		end
-
-		if
-			current_mode:lower() == 'v'
-			or current_mode == utils.replace_termcodes('<c-v>')
-		then
-			if
-				key == utils.replace_termcodes('<esc>')
-				or key == current_mode
-			then
-				M.reset()
-			end
+			   end
+		   end
 		end
 	end)
 


### PR DESCRIPTION
I just discovered your plugin and I really like the eye candy :smile: very nice work

I found a bug when also use [vim-cutlass](https://github.com/svermeulen/vim-cutlass)(or similar mappings): the highlighting gets stuck in operator mode

#### To reproduce:
-  set a mapping like `noremap d "_d`
- press `d` and wait for the operator highlighting to become active
- press another key (e.g. `e`) to end the operator mode
- the highlighting will stick with the cursor until the next mode change

![ezgif-2-f24fc48032](https://user-images.githubusercontent.com/6849129/188198480-0630f4de-ae1d-442b-8fb8-f64553f76cf5.gif)

I checked the code streamlined it a bit and reset the operator highlighting on the next key press.
So far it is working without any errors for me