### PR TITLE
feat: handle visual highlight using ModeChanged event 

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -223,18 +223,9 @@ M.setup = function(opts)
 				operator_started = true
 				return
 			end
-
-			if
-				key:lower() == 'v'
-				or key == utils.replace_termcodes('<c-v>')
-			then
-				M.highlight('visual')
-				operator_started = true
-				return
-			end
 		end
 
-		if key == utils.replace_termcodes('<esc>') or key == current_mode then
+		if key == utils.replace_termcodes('<esc>') then
 			M.reset()
 			return
 		end
@@ -254,9 +245,17 @@ M.setup = function(opts)
 		end,
 	})
 
+	---Set visual highlight
+	vim.api.nvim_create_autocmd('ModeChanged', {
+		pattern = '*:[vV\x16]',
+		callback = function()
+			M.highlight('visual')
+		end,
+	})
+
 	---Reset highlights
 	vim.api.nvim_create_autocmd(
-		{ 'CmdlineLeave', 'InsertLeave', 'TextYankPost', 'WinNew', 'WinLeave' },
+		{ 'CmdlineLeave', 'InsertLeave', 'TextYankPost', 'WinLeave' },
 		{
 			pattern = '*',
 			callback = M.reset,

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -221,21 +221,23 @@ M.setup = function(opts)
 					operator_started = true
 					return
 				end
+
+				if
+					key:lower() == 'v'
+					or key == utils.replace_termcodes('<c-v>')
+				then
+					M.highlight('visual')
+					operator_started = true
+					return
+				end
 			end
 
 			if
-				current_mode:lower() == 'v'
-				or current_mode == utils.replace_termcodes('<c-v>')
+				key == utils.replace_termcodes('<esc>')
+				or key == current_mode
 			then
-				if
-					key == utils.replace_termcodes('<esc>')
-					or key == current_mode
-				then
-					M.reset()
-				else
-					M.highlight('visual')
-					operator_started = true
-				end
+				M.reset()
+				return
 			end
 		end
 	end)

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -256,7 +256,7 @@ M.setup = function(opts)
 
 	---Reset highlights
 	vim.api.nvim_create_autocmd(
-		{ 'CmdlineLeave', 'InsertLeave', 'TextYankPost', 'WinLeave' },
+		{ 'CmdlineLeave', 'InsertLeave', 'TextYankPost', 'WinNew', 'WinLeave' },
 		{
 			pattern = '*',
 			callback = M.reset,

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -195,50 +195,48 @@ M.setup = function(opts)
 		local ok, current_mode = pcall(vim.fn.mode)
 		if not ok then
 			M.reset()
-		else
-			if current_mode == 'i' then
-				if key == utils.replace_termcodes('<esc>') then
-					M.reset()
-					return
-				end
-			end
+			return
+		end
 
-			if current_mode == 'n' then
-				-- reset if coming back from operator pending mode
-				if operator_started then
-					M.reset()
-					return
-				end
-
-				if key == 'y' then
-					M.highlight('copy')
-					operator_started = true
-					return
-				end
-
-				if key == 'd' then
-					M.highlight('delete')
-					operator_started = true
-					return
-				end
-
-				if
-					key:lower() == 'v'
-					or key == utils.replace_termcodes('<c-v>')
-				then
-					M.highlight('visual')
-					operator_started = true
-					return
-				end
-			end
-
-			if
-				key == utils.replace_termcodes('<esc>')
-				or key == current_mode
-			then
+		if current_mode == 'i' then
+			if key == utils.replace_termcodes('<esc>') then
 				M.reset()
 				return
 			end
+		end
+
+		if current_mode == 'n' then
+			-- reset if coming back from operator pending mode
+			if operator_started then
+				M.reset()
+				return
+			end
+
+			if key == 'y' then
+				M.highlight('copy')
+				operator_started = true
+				return
+			end
+
+			if key == 'd' then
+				M.highlight('delete')
+				operator_started = true
+				return
+			end
+
+			if
+				key:lower() == 'v'
+				or key == utils.replace_termcodes('<c-v>')
+			then
+				M.highlight('visual')
+				operator_started = true
+				return
+			end
+		end
+
+		if key == utils.replace_termcodes('<esc>') or key == current_mode then
+			M.reset()
+			return
 		end
 	end)
 

--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -253,6 +253,12 @@ M.setup = function(opts)
 		end,
 	})
 
+	---Reset visual highlight
+	vim.api.nvim_create_autocmd('ModeChanged', {
+		pattern = '[vV\x16]:n',
+		callback = M.reset,
+	})
+
 	---Reset highlights
 	vim.api.nvim_create_autocmd(
 		{ 'CmdlineLeave', 'InsertLeave', 'TextYankPost', 'WinLeave' },


### PR DESCRIPTION
cb54e80 introduce changes to check visual mode highlight using
`current_mode`, this changes causes a bug with `Shift + v` (visual
line mode) where the cursor highlight still uses the default `Visual`
highlight until pressing the second key.

~~Checking visual mode highlights Using `key` (and checking it inside
`current_mode == 'n'`) is more reliable than using `current_mode`.~~

**Update**

We can completely avoid checking `key` or `current_mode` for visual highlight by using autocmd on these events:

- `ModeChanged *:[vV\x16]` for set highlight
- `ModeChanged [vV\x16]:n` for reset