### PR TITLE
fix: remove unnecessary reset

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -234,11 +234,6 @@ M.setup = function(opts)
 				return
 			end
 		end
-
-		if key == utils.replace_termcodes('<esc>') then
-			M.reset()
-			return
-		end
 	end)
 
 	---Set highlights when colorscheme changes


### PR DESCRIPTION
This reset causes problems with f/t motion, e.g. `vwf<Esc>t(`, `<Esc>` resets the highlight to normal while we are still in visual mode, the correct behavior is:

* `<Esc>` cancels the `f` motion
* we are still in visual highlight
* proceed with the `t` motion

This reset was intended as a *catch all* condition, but since we already have `InsertLeave` and `ModeChanged` to reset insert and visual mode, this reset is no longer needed.