### PR TITLE
fix: do not overwrite user's `guicursor` shape

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -174,9 +174,9 @@ M.enable_managed_ui = function()
 	end
 
 	if config.set_cursor then
-		vim.opt.guicursor:append('v-sm:block-ModesVisual')
-		vim.opt.guicursor:append('i-ci-ve:ver25-ModesInsert')
-		vim.opt.guicursor:append('r-cr-o:hor20-ModesOperator')
+		vim.opt.guicursor:append('v-sm:ModesVisual')
+		vim.opt.guicursor:append('i-ci-ve:ModesInsert')
+		vim.opt.guicursor:append('r-cr-o:ModesOperator')
 	end
 
 	if config.set_cursorline then
@@ -190,9 +190,9 @@ M.disable_managed_ui = function()
 	end
 
 	if config.set_cursor then
-		vim.opt.guicursor:remove('v-sm:block-ModesVisual')
-		vim.opt.guicursor:remove('i-ci-ve:ver25-ModesInsert')
-		vim.opt.guicursor:remove('r-cr-o:hor20-ModesOperator')
+		vim.opt.guicursor:remove('v-sm:ModesVisual')
+		vim.opt.guicursor:remove('i-ci-ve:ModesInsert')
+		vim.opt.guicursor:remove('r-cr-o:ModesOperator')
 	end
 
 	if config.set_cursorline then


### PR DESCRIPTION
fixes #54. removed the cursor shape options (e.g. `block`, `ver25`. `hor20`) from being set in the `guicursor`. now this plugin only handles the highlighting.

for example, the following line:
```lua
vim.opt.guicursor:append('v-sm:block-ModesVisual')
```
was changed to:
```lua
vim.opt.guicursor:append('v-sm:ModesVisual')
```