### PR TITLE
fix: add custom blend bg

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -128,28 +128,28 @@ M.highlight = function(scene)
 end
 
 M.define = function()
-	local normal_bg = utils.get_bg('Normal', 'Normal')
 	colors = {
+		bg = config.colors.bg or utils.get_bg('Normal', 'Normal'),
 		copy = config.colors.copy or utils.get_bg('ModesCopy', '#f5c359'),
 		delete = config.colors.delete or utils.get_bg('ModesDelete', '#c75c6a'),
 		insert = config.colors.insert or utils.get_bg('ModesInsert', '#78ccc5'),
 		visual = config.colors.visual or utils.get_bg('ModesVisual', '#9745be'),
 	}
 	blended_colors = {
-		copy = utils.blend(colors.copy, normal_bg, config.line_opacity.copy),
+		copy = utils.blend(colors.copy, colors.bg, config.line_opacity.copy),
 		delete = utils.blend(
 			colors.delete,
-			normal_bg,
+			colors.bg,
 			config.line_opacity.delete
 		),
 		insert = utils.blend(
 			colors.insert,
-			normal_bg,
+			colors.bg,
 			config.line_opacity.insert
 		),
 		visual = utils.blend(
 			colors.visual,
-			normal_bg,
+			colors.bg,
 			config.line_opacity.visual
 		),
 	}

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ use({
 ```lua
 require('modes').setup({
 	colors = {
+		bg = "", -- Optional bg param, defaults to Normal hl group
 		copy = "#f5c359",
 		delete = "#c75c6a",
 		insert = "#78ccc5",


### PR DESCRIPTION
I noticed that when using a transparent bg in neovim the blend function blends a bit weird as the Normal bg is set to "none". To fix this I wanted to add an optional color bg prop that can be used when blending.

#### Without custom bg
![Screenshot 2024-06-05 103400](https://github.com/mvllow/modes.nvim/assets/113891532/abb449d1-4711-4117-95d2-812c0003903c)

#### With custom bg
![Screenshot 2024-06-05 103436](https://github.com/mvllow/modes.nvim/assets/113891532/4e3ab847-8ef6-4ed1-bd2a-95250c35d18b)
