### PR TITLE
feat: allow disabling entire modes

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -155,10 +155,18 @@ M.define = function()
 	}
 
 	---Create highlight groups
-	vim.cmd('hi ModesCopy guibg=' .. colors.copy)
-	vim.cmd('hi ModesDelete guibg=' .. colors.delete)
-	vim.cmd('hi ModesInsert guibg=' .. colors.insert)
-	vim.cmd('hi ModesVisual guibg=' .. colors.visual)
+	if colors.copy ~= "" then
+		vim.cmd('hi ModesCopy guibg=' .. colors.copy)
+	end
+	if colors.delete ~= "" then
+		vim.cmd('hi ModesDelete guibg=' .. colors.delete)
+	end
+	if colors.insert ~= "" then
+		vim.cmd('hi ModesInsert guibg=' .. colors.insert)
+	end
+	if colors.visual ~= "" then
+		vim.cmd('hi ModesVisual guibg=' .. colors.visual)
+	end
 
 	local default_cursorline = utils.get_bg('CursorLine', '#26233a')
 
@@ -171,16 +179,22 @@ M.define = function()
 	end
 
 	for _, mode in ipairs({ 'Copy', 'Delete', 'Insert', 'Visual' }) do
-		local def = { bg = blended_colors[mode:lower()] }
-		utils.set_hl(('Modes%sCursorLine'):format(mode), def)
-		utils.set_hl(('Modes%sCursorLineNr'):format(mode), def)
-		utils.set_hl(('Modes%sCursorLineSign'):format(mode), def)
-		utils.set_hl(('Modes%sCursorLineFold'):format(mode), def)
+		if colors[mode:lower()] ~= "" then
+			local def = { bg = blended_colors[mode:lower()] }
+			utils.set_hl(('Modes%sCursorLine'):format(mode), def)
+			utils.set_hl(('Modes%sCursorLineNr'):format(mode), def)
+			utils.set_hl(('Modes%sCursorLineSign'):format(mode), def)
+			utils.set_hl(('Modes%sCursorLineFold'):format(mode), def)
+		end
 	end
 
-	utils.set_hl('ModesInsertModeMsg', { fg = colors.insert })
-	utils.set_hl('ModesVisualModeMsg', { fg = colors.visual })
-	utils.set_hl('ModesVisualVisual', { bg = blended_colors.visual })
+	if colors.insert ~= "" then
+		utils.set_hl('ModesInsertModeMsg', { fg = colors.insert })
+	end
+	if colors.visual ~= "" then
+		utils.set_hl('ModesVisualModeMsg', { fg = colors.visual })
+		utils.set_hl('ModesVisualVisual', { bg = blended_colors.visual })
+	end
 end
 
 M.enable_managed_ui = function()


### PR DESCRIPTION
This PR allows users to fully disable a given mode's color if the string is empty, like so;
```lua
require("modes").setup({
	colors = {
		insert = "", -- disabled
		copy = "#f5c359",
		delete = "#c75c6a",
		visual = "#b07fc7"
	}
})
``` 
It simply checks if the mode's string is empty before setting the highlights in `define`.

I made this since just setting the opacity to zero to disable it didn't actually remove the color, merely make it verryyy subtle. This is with the insert color set to `#FFFFFF` and opacity to 0:
![Pasted image 20250125173730](https://github.com/user-attachments/assets/8a602a4d-73c8-4f31-a0bc-92b24e8a2688)
Setting it to `#000000`:
![Pasted image 20250125173809](https://github.com/user-attachments/assets/9c410c4f-752e-4f75-a80f-d1ba9bf38759)
Versus when the plugin is disabled, aka my expected result and what this PR does instead...
![Pasted image 20250125173459](https://github.com/user-attachments/assets/94abec9b-081b-404b-9a58-252d06c24330)

This may just be an issue with my colorscheme [Oxocarbon](https://github.com/nyoom-engineering/oxocarbon.nvim), similar to what _seems_ to be happening in #41, but even then this at least acts as a fix for those colorschemes that don't play nicely.