### PR TITLE
added support for phat cursor

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -216,9 +216,13 @@ M.enable_managed_ui = function()
 		return
 	end
 
-	local cursor_hl = ',v-sm:ModesVisual,i-ci-ve:ModesInsert,r-cr-o:ModesOperator'
+	local cursor_hl = 'v-sm:ModesVisual,i-ci-ve:ModesInsert,r-cr-o:ModesOperator'
 	if config.set_cursor then
-		vim.o.guicursor = vim.o.guicursor .. cursor_hl
+		if vim.o.guicursor == '' then
+			vim.o.guicursor = cursor_hl
+		else
+			vim.o.guicursor = vim.o.guicursor .. ',' .. cursor_hl
+		end
 	end
 
 	if config.set_cursorline then

--- a/lua/modes/utils.lua
+++ b/lua/modes/utils.lua
@@ -73,7 +73,6 @@ M.get_fg = function(name, fallback)
 
 	return foreground
 end
-
 M.get_bg = function(name, fallback)
 	local id = vim.api.nvim_get_hl_id_by_name(name)
 	if not id then


### PR DESCRIPTION
Hey there, I was excited to use this plugin but then everything was breaking and I realized it's because I had the opt.guicursor = "", so I added logic to handle this.

It feels a little sneaky because there is no config option to bypass it, I just thought I would make the PR and see what you think. I am more than happy to work on it more if you have a better way of doing it!

One test doesn't pass, but I am pretty sure it wasn't passing before I made my change, if that's not the case then I have no problem fixing that, I just might need some help understanding why, I tried reading the nvim manual about synIDattr but I don't really get it lol.