### PR TITLE
fix: remove command-line cursor highlighting

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -222,8 +222,8 @@ M.enable_managed_ui = function()
 
 		if config.set_cursor then
 			vim.opt.guicursor:append('v-sm:ModesVisual')
-			vim.opt.guicursor:append('i-ci-ve:ModesInsert')
-			vim.opt.guicursor:append('r-cr-o:ModesOperator')
+			vim.opt.guicursor:append('i-ve:ModesInsert')
+			vim.opt.guicursor:append('r-o:ModesOperator')
 		end
 	end
 end
@@ -235,8 +235,8 @@ M.disable_managed_ui = function()
 
 	if config.set_cursor then
 		vim.opt.guicursor:remove('v-sm:ModesVisual')
-		vim.opt.guicursor:remove('i-ci-ve:ModesInsert')
-		vim.opt.guicursor:remove('r-cr-o:ModesOperator')
+		vim.opt.guicursor:remove('i-ve:ModesInsert')
+		vim.opt.guicursor:remove('r-o:ModesOperator')
 
 		-- ensure cursor reset (see https://github.com/neovim/neovim/issues/21018)
 		local cursor = vim.o.guicursor


### PR DESCRIPTION
As discussed in #74, this pull request removes command-line cursor highlighting. See also https://github.com/mvllow/modes.nvim/pull/75#discussion_r2105787245.