### PR TITLE
fix: mode and operator detection

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -226,7 +226,7 @@ M.define = function()
 	end
 end
 
-M.enable_managed_ui = vim.schedule_wrap(function()
+M.enable_managed_ui = function()
 	if in_ignored_buffer() then
 		if config.set_cursorline then
 			vim.o.cursorline = false
@@ -244,7 +244,7 @@ M.enable_managed_ui = vim.schedule_wrap(function()
 
 		M.restore()
 	end
-end)
+end
 
 M.disable_managed_ui = function()
 	if config.set_cursorline then
@@ -343,7 +343,9 @@ M.setup = function(opts)
 	---Enable managed UI for current window
 	vim.api.nvim_create_autocmd({ 'WinEnter', 'FocusGained' }, {
 		pattern = '*',
-		callback = M.enable_managed_ui,
+		callback = function()
+			vim.schedule(M.enable_managed_ui)
+		end,
 	})
 
 	---Disable managed UI


### PR DESCRIPTION
This pull request addresses #77.

As noted in #77, modes may incorrectly recognize `y` and `d` as copy and delete operations even after a motion prefix like `f` or `[`. A possible solution to this problem is to verify that `y` and `d` have indeed triggered operator-pending mode (a mode that would not have been triggered if Neovim was waiting for a character to complete a motion). This solution also presents an opportunity to manage aborted operations with a general resetting strategy.

This pull request additionally includes broader support for insert and visual modes and a minor refactor of the enable and disable logic.