### PR TITLE
fix: ensure enabled when lazy loading

### DIFF
--- a/lua/modes.lua
+++ b/lua/modes.lua
@@ -299,6 +299,7 @@ M.setup = function(opts)
 	end
 
 	M.define()
+	M.enable_managed_ui() -- ensure enabled initially
 
 	---Reset normal highlight
 	vim.api.nvim_create_autocmd('ModeChanged', {


### PR DESCRIPTION
 If modes is lazy loaded, then it might not be enabled properly because it might miss the event (`WinEnter`) that triggers `enable_managed_ui`. This small fix runs `enable_managed_ui` in `setup`, ensuring that modes is properly enabled from the start.